### PR TITLE
Remove redundant dataset copy from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 
 # Copy project files into the container
 COPY . /app
-COPY Data/nc-education-data.parquet /app/Data/nc-education-data.parquet
 
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- streamline the Dockerfile by relying on the initial `COPY . /app`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68409e4ade888326aa0a3441b5e9b76d